### PR TITLE
Make lifebars fade away, fix memory leaks in lifebars and minimap

### DIFF
--- a/core/src/thwack/Dungeon.java
+++ b/core/src/thwack/Dungeon.java
@@ -87,7 +87,7 @@ public class Dungeon {
 	}
 	
 	public void advanceToNextStage(World world, Array<Updateable> updateables) {
-		System.out.println("Advancing to next stage");
+		Global.DebugOutLine("Advancing to next stage");
 		if (currentStage+1 < stages.size()) {
 			currentStage++;
 			if (thisDungeonType == DungeonType.timedStages) {
@@ -100,7 +100,7 @@ public class Dungeon {
 			stages.get(currentStage).beginStage(stageTemplates.get(currentStage), world, updateables);
 		}
 		else {
-			System.out.println("No more stages...");
+			Global.DebugOutLine("No more stages...");
 		}
 	}
 	

--- a/core/src/thwack/DungeonStage.java
+++ b/core/src/thwack/DungeonStage.java
@@ -50,15 +50,15 @@ public class DungeonStage {
 	}
 	
 	public void buildFromString(String mobString, World world, Array<Updateable> updateables) {
-		System.out.print("Building stage from string");
+		Global.DebugOut("Building stage from string");
 		String[] mobTypes = mobString.split(" ");
-		System.out.print("...got " + mobTypes.length + " types of mobs");
+		Global.DebugOut("...got " + mobTypes.length + " types of mobs");
 		for (int i=0;i<mobTypes.length;i++) {
 			int MOBTYPE =0;
 			int MOBCOUNT = 1;
 			String[] thisMobType = mobTypes[i].split("=");
 			int mobCount = Integer.parseInt(thisMobType[MOBCOUNT]);
-			System.out.print("...Creating " + mobCount + " of " + thisMobType[MOBTYPE]);
+			Global.DebugOut("...Creating " + mobCount + " of " + thisMobType[MOBTYPE]);
 			for (int n=0;n<mobCount;n++) {
 				if (thisMobType[MOBTYPE].equals("rat")) {
 			        Vector2 ratPos = new Vector2(6f, 25f);
@@ -86,7 +86,7 @@ public class DungeonStage {
 				}
 			}
 		}
-		System.out.println("");
+		Global.DebugOutLine("");
 	}
 	
 	public void beginStage(String stageTemplate, World world, Array<Updateable> updateables) {
@@ -98,7 +98,6 @@ public class DungeonStage {
 		long thisNanoTick = System.nanoTime();
 		elapsedNanoSeconds += thisNanoTick - lastNanoTick;
 		elapsedSeconds = TimeUnit.SECONDS.convert(elapsedNanoSeconds,TimeUnit.NANOSECONDS);
-		//System.out.println("" + elapsedSeconds);
 		lastNanoTick = System.nanoTime();
 		if (dungeonType == DungeonType.clearStages) {
 			//check to see if any living mobs are left

--- a/core/src/thwack/Global.java
+++ b/core/src/thwack/Global.java
@@ -14,5 +14,17 @@ public class Global {
     public static SpriteBatch   batch;
     public static BitmapFont    font;
     public static ShapeRenderer shapeRenderer;
+    
+    public static boolean verbose = true;		//whether or not to do debug output
+    
+    public static void DebugOut(String s)
+    {
+    	if (verbose == true) System.out.print(s);
+    }
+    
+    public static void DebugOutLine(String s)
+    {
+    	if (verbose == true) System.out.println(s);
+    }
 
 }

--- a/core/src/thwack/model/entities/mobs/Aimer.java
+++ b/core/src/thwack/model/entities/mobs/Aimer.java
@@ -1,8 +1,7 @@
 package thwack.model.entities.mobs;
 
+import thwack.Global;
 import thwack.model.entity.Lifebar;
-
-
 import thwack.model.entities.player.Player;
 import thwack.model.entities.projectiles.FireBall;
 import thwack.model.entities.projectiles.FireOrbital;
@@ -54,6 +53,7 @@ public class Aimer extends Mob {
 		this.increaseDamageStateTime(deltaTime);
 		this.increaseStateTime(deltaTime);
 		moveLogic(3f);
+		lifebar.updateTime(deltaTime);
 	}
 	
 	@Override
@@ -162,17 +162,18 @@ public class Aimer extends Mob {
 	public void setHealth(int health) {
 		this.currentHealth = health;
 		this.maxHealth = health;
-		lifebar.update(currentHealth, maxHealth);
+		lifebar.updateImage(currentHealth, maxHealth);
 	}
 
 	@Override
 	public void applyHit(int damage, Entity attacker) {
 		currentHealth -= damage;
-		lifebar.update(currentHealth, maxHealth);
+		lifebar.updateImage(currentHealth, maxHealth);
+		lifebar.makeVisible();
 		if(currentHealth < 1) {
 			setPublicState(EntityState.DESTROY);
 			attacker.stats.killCount++;
-			System.out.println(attacker + " kills: " + attacker.stats.killCount);
+			Global.DebugOutLine(attacker + " kills: " + attacker.stats.killCount);
 		}
 	}
 

--- a/core/src/thwack/model/entities/mobs/MobGroup.java
+++ b/core/src/thwack/model/entities/mobs/MobGroup.java
@@ -13,10 +13,14 @@ public class MobGroup {
 	ArrayList<Aimer> aimers;
 	ArrayList<SawRat> sawrats;
 	
+	ArrayList<Mob> mobs;
+	
 	public MobGroup() {
 		rats = new ArrayList<Rat>();
 		aimers = new ArrayList<Aimer>();
 		sawrats = new ArrayList<SawRat>();
+		
+		mobs = new ArrayList<Mob>();
 	}
 	
 	

--- a/core/src/thwack/model/entities/mobs/Rat.java
+++ b/core/src/thwack/model/entities/mobs/Rat.java
@@ -1,5 +1,6 @@
 package thwack.model.entities.mobs;
 
+import thwack.Global;
 import thwack.model.entity.Entity;
 import thwack.model.entity.Lifebar;
 import thwack.model.entity.Stateable.EntityState;
@@ -46,6 +47,7 @@ public class Rat extends Mob {
 		this.increaseDamageStateTime(deltaTime);
 		this.increaseStateTime(deltaTime);
 		moveLogic(3f);
+		lifebar.updateTime(deltaTime);
 	}
 	
 	@Override
@@ -116,17 +118,18 @@ public class Rat extends Mob {
 	public void setHealth(int health) {
 		this.maxHealth = health;
 		this.currentHealth = health;
-		lifebar.update(currentHealth, maxHealth);
+		lifebar.updateImage(currentHealth, maxHealth);
 	}
 
 	@Override
 	public void applyHit(int damage, Entity attacker) {
 		currentHealth -= damage;
-		lifebar.update(currentHealth, maxHealth);
+		lifebar.updateImage(currentHealth, maxHealth);
+		lifebar.makeVisible();
 		if(currentHealth < 1) {
 			setPublicState(EntityState.DESTROY);
 			attacker.stats.killCount++;
-			System.out.println(attacker + " kills: " + attacker.stats.killCount);
+			Global.DebugOutLine(attacker + " kills: " + attacker.stats.killCount);
 		}
 	}
 

--- a/core/src/thwack/model/entities/mobs/SawRat.java
+++ b/core/src/thwack/model/entities/mobs/SawRat.java
@@ -1,5 +1,6 @@
 package thwack.model.entities.mobs;
 
+import thwack.Global;
 import thwack.model.entities.mobs.Mob.State;
 import thwack.model.entity.Entity;
 import thwack.model.entity.Lifebar;
@@ -39,7 +40,7 @@ public class SawRat extends Mob {
 		
 
 		lifebar = new Lifebar();
-		setHealth(8);
+		setHealth(4);
 
 	}
 	
@@ -48,6 +49,7 @@ public class SawRat extends Mob {
 		this.increaseDamageStateTime(deltaTime);
 		this.increaseStateTime(deltaTime);
 		moveLogic(3f);
+		lifebar.updateTime(deltaTime);
 	}
 	
 	@Override
@@ -118,17 +120,18 @@ public class SawRat extends Mob {
 	public void setHealth(int health) {
 		this.maxHealth = health;
 		this.currentHealth = health;
-		lifebar.update(currentHealth, maxHealth);
+		lifebar.updateImage(currentHealth, maxHealth);
 	}
 
 	@Override
 	public void applyHit(int damage, Entity attacker) {
 		currentHealth -= damage;
-		lifebar.update(currentHealth, maxHealth);
+		lifebar.updateImage(currentHealth, maxHealth);
+		lifebar.makeVisible();
 		if(currentHealth < 1) {
 			setPublicState(EntityState.DESTROY);
 			attacker.stats.killCount++;
-			System.out.println(attacker + " kills: " + attacker.stats.killCount);
+			Global.DebugOutLine(attacker + " kills: " + attacker.stats.killCount);
 		}
 	}
 

--- a/core/src/thwack/model/entity/Lifebar.java
+++ b/core/src/thwack/model/entity/Lifebar.java
@@ -1,9 +1,12 @@
 package thwack.model.entity;
 
+import thwack.Global;
+
 import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.Pixmap;
 import com.badlogic.gdx.graphics.Texture;
 import com.badlogic.gdx.graphics.Pixmap.Format;
+import com.badlogic.gdx.graphics.g2d.Sprite;
 
 public class Lifebar {
 
@@ -14,6 +17,13 @@ public class Lifebar {
 													//is hard coded at 2.
 
 	Texture lifebarImage;
+	Sprite lifebarSprite;
+	
+	public float scaleFactor=16;
+	public float xOffset;							//offset based on mob's size
+	public float yOffset =-3;
+	public float lifebarAlpha = 0f;
+	public float lifebarFadeTimer = 0.0f;
 
 	
 	public Lifebar() {
@@ -22,21 +32,40 @@ public class Lifebar {
 	}
 	
 	public Texture getImage() { return lifebarImage; }
+	public Sprite getSprite() { return lifebarSprite; }
 	public float getWidth() { return lifebarWidth; }
 	public float getHeight() { return lifebarHeight; }
 	
-	public void update(int curHP, int maxHP) {
+	public void updateTime(float deltaTime)
+	{
+		//Global.DebugOutLine("" + deltaTime);
+		if (lifebarFadeTimer < 0)
+		{
+			lifebarAlpha -= deltaTime;
+			if (lifebarAlpha < 0) lifebarAlpha = 0;
+		}
+		else lifebarFadeTimer -= deltaTime;
+	}
+
+	public void makeVisible()
+	{
+		lifebarAlpha = 1.0f;
+		lifebarFadeTimer = 2.0f;
+	}
+	
+	public void updateImage(int curHP, int maxHP) {
 		if (maxHP > 32) {
-			System.out.println("TODO: Handle maxhp > 32 for lifebarS");
+			Global.DebugOutLine("TODO: Handle maxhp > 32 for lifebarS");
 		}
 		else {
 			lifebarWidth = maxHP;
+			xOffset =  - ( (lifebarWidth) / scaleFactor);
 			Pixmap lifebarPixels = new Pixmap(32,32,Format.RGBA8888);
 			
-			int starty = lifebarPixels.getHeight() - (int)lifebarHeight -15;
-			int endy = starty + (int)lifebarHeight;
-			int startx = lifebarPixels.getWidth()/2 - (int)lifebarWidth;
-			int endx = startx + (int)lifebarWidth;
+			int starty = 0;
+			int startx = 0;
+			int endy = (int)lifebarHeight;
+			int endx = (int)lifebarWidth;
 			
 			for (int y = starty; y< endy; y++) {
 				for (int x =startx;x<endx;x++) {
@@ -47,6 +76,8 @@ public class Lifebar {
 				}
 			}
 			lifebarImage = new Texture(lifebarPixels,Format.RGBA8888,false);
+			lifebarSprite = new Sprite(lifebarImage);
+			lifebarSprite.setAlpha(0.1f);
 			
 		}
 	}

--- a/core/src/thwack/model/entity/Lifebar.java
+++ b/core/src/thwack/model/entity/Lifebar.java
@@ -75,7 +75,9 @@ public class Lifebar {
 					lifebarPixels.drawPixel(x,y);
 				}
 			}
+			if (lifebarImage != null) lifebarImage.dispose();
 			lifebarImage = new Texture(lifebarPixels,Format.RGBA8888,false);
+			lifebarPixels.dispose();
 			lifebarSprite = new Sprite(lifebarImage);
 			lifebarSprite.setAlpha(0.1f);
 			

--- a/core/src/thwack/screen/GameScreen.java
+++ b/core/src/thwack/screen/GameScreen.java
@@ -1,13 +1,9 @@
 package thwack.screen;
 
 import thwack.Constants;
-import thwack.DungeonStage;
 import thwack.Dungeon;
 import thwack.Global;
 import thwack.controller.MyContactListener;
-import thwack.model.entities.mobs.Aimer;
-import thwack.model.entities.mobs.MobGroup;
-import thwack.model.entities.mobs.Rat;
 import thwack.model.entities.player.Player;
 import thwack.model.entities.projectiles.Projectile;
 import thwack.model.entities.worldobjects.Wall;

--- a/core/src/thwack/view/AimerRenderer.java
+++ b/core/src/thwack/view/AimerRenderer.java
@@ -46,13 +46,9 @@ public class AimerRenderer implements Disposable {
 		ratWalkAnim.put(Direction.RIGHT, new Animation(ratAnimSpeed, ratAtlas.findRegions("Run Right/Rat Run Side"), PlayMode.LOOP));
 		ratWalkAnim.put(Direction.UP, new Animation(ratAnimSpeed, ratAtlas.findRegions("Run Up/Rat Run Up"), PlayMode.LOOP));
 		ratBoredAnim1.put(Direction.DOWN, new Animation(ratAnimSpeed, ratAtlas.findRegions("Bored Down/Clean/Rat Clean Down"), PlayMode.LOOP));
-		System.out.println("Adding rat animation: " + ratAtlas.findRegions("Bored Down/Clean/Rat Clean Down"));
 		ratBoredAnim1.put(Direction.LEFT, new Animation(ratAnimSpeed, ratAtlas.findRegions("Bored Side/Clean/Rat Clean Side"), PlayMode.LOOP));
-		System.out.println("Adding rat animation: " + ratAtlas.findRegions("Bored Side/Clean/Rat Clean Side"));
 		ratBoredAnim1.put(Direction.RIGHT, new Animation(ratAnimSpeed, ratAtlas.findRegions("Bored Side/Clean/Rat Clean Side"), PlayMode.LOOP));
-		System.out.println("Adding rat animation: " + ratAtlas.findRegions("Bored Side/Clean/Rat Clean Side"));
 		ratBoredAnim1.put(Direction.UP, new Animation(ratAnimSpeed, ratAtlas.findRegions("Bored Up/Clean/Rat Clean Up"), PlayMode.LOOP));
-		System.out.println("Adding rat animation: " + ratAtlas.findRegions("Bored Up/Clean/Rat Clean Up"));
 
 		//i tweaked these to get the look times feeling right --radish
 		ratBoredAnim2.put(Direction.DOWN, new Animation(.75f, ratAtlas.findRegions("Bored Down/Look/Rat Look Down"), PlayMode.LOOP));

--- a/core/src/thwack/view/LifebarRenderer.java
+++ b/core/src/thwack/view/LifebarRenderer.java
@@ -11,10 +11,9 @@ import thwack.model.entity.Lifebar;
 
 
 
+
+
 import com.badlogic.gdx.graphics.Color;
-import com.badlogic.gdx.graphics.Pixmap;
-import com.badlogic.gdx.graphics.Texture;
-import com.badlogic.gdx.graphics.Pixmap.Format;
 import com.badlogic.gdx.graphics.g2d.SpriteBatch;
 import com.badlogic.gdx.graphics.glutils.ShapeRenderer;
 import com.badlogic.gdx.utils.Disposable;
@@ -23,9 +22,6 @@ public class LifebarRenderer implements Disposable {
 	SpriteBatch batch;
 	ShapeRenderer shapeRenderer;
 	
-	float lifebarAlpha = 0.5f;
-	
-
 	public LifebarRenderer(SpriteBatch batch, ShapeRenderer shapeRenderer) {
 		
 		this.batch = batch;
@@ -34,8 +30,15 @@ public class LifebarRenderer implements Disposable {
 	
 	public void render(float xLoc, float yLoc, Lifebar lifebar) {	
 		
+		
 		if (lifebar.getImage() != null) { 
-			batch.draw(lifebar.getImage(),xLoc - (lifebar.getWidth() / 2),yLoc, lifebar.getWidth(),lifebar.getHeight());
+			
+			//batch.draw(lifebar.getImage(),xLoc  + lifebar.xOffset,yLoc + lifebar.yOffset, lifebar.getWidth(),lifebar.getHeight());
+			//lifebar.getSprite().setAlpha(lifebarAlpha);
+			Color c = batch.getColor();
+            batch.setColor(c.r, c.g, c.b, lifebar.lifebarAlpha); 
+			batch.draw(lifebar.getSprite(),xLoc  + lifebar.xOffset,yLoc + lifebar.yOffset, lifebar.getWidth(),lifebar.getHeight());
+            batch.setColor(c.r, c.g, c.b, 1f);
 			
 		}
 		

--- a/core/src/thwack/view/MinimapRenderer.java
+++ b/core/src/thwack/view/MinimapRenderer.java
@@ -3,7 +3,6 @@ package thwack.view;
 
 
 import thwack.Dungeon;
-import thwack.model.entities.mobs.Aimer;
 import thwack.model.entities.mobs.MobGroup;
 import thwack.model.entities.player.Player;
 
@@ -16,7 +15,6 @@ import com.badlogic.gdx.graphics.glutils.ShapeRenderer;
 import com.badlogic.gdx.maps.tiled.TiledMap;
 import com.badlogic.gdx.maps.tiled.TiledMapTileLayer;
 import com.badlogic.gdx.maps.tiled.TiledMapTileLayer.Cell;
-import com.badlogic.gdx.utils.Array;
 import com.badlogic.gdx.utils.Disposable;
 
 public class MinimapRenderer implements Disposable {
@@ -29,10 +27,10 @@ public class MinimapRenderer implements Disposable {
 	float minimapAlpha = 0.5f;
 	Texture mapTerrainImage;
 	
-	int MINIMAP_WIDTH_PIXELS = 56;
-	int MINIMAP_HEIGHT_PIXELS = 36;
+	int MINIMAP_WIDTH_PIXELS = 64;
+	int MINIMAP_HEIGHT_PIXELS = 64;
 	//these offsets are for walls or something
-	int XOFFSET = 1;
+	int XOFFSET = 0;
 	int YOFFSET = 1;
 	
 
@@ -50,10 +48,8 @@ public class MinimapRenderer implements Disposable {
 	public void render(Dungeon thisDungeon) {
 	
 		MobGroup mobs = thisDungeon.getCurrentStage().getMobs();
-		//batch.draw(mapTerrainImage,-20f,20f);
 		batch.draw(mapTerrainImage,-20f,70f);
 		Texture radarImage = new Texture(getUpdatedRadar(mobs), Format.RGBA8888, false);
-		//batch.draw(radarImage,-20f,20f);
 		batch.draw(radarImage,-20f,70f);
 		
 	}
@@ -113,9 +109,6 @@ public class MinimapRenderer implements Disposable {
 			}
 		}
 		
-		//terrainPixels.drawPixel(0,0);
-		//terrainPixels.drawPixel(MINIMAP_WIDTH_PIXELS-1,MINIMAP_HEIGHT_PIXELS-1);
-		
 		mapTerrainImage = new Texture(terrainPixels,Format.RGBA8888,false);
 	}
 	
@@ -126,7 +119,7 @@ public class MinimapRenderer implements Disposable {
 		
 		
 		//draw rats on radar
-		//System.out.println("On minimap, ,drawing " + mobs.getRatCount() + " rats and " + mobs.getAimerCount() + "aimers.");
+		//Global.DebugOutLine("On minimap, ,drawing " + mobs.getRatCount() + " rats and " + mobs.getAimerCount() + "aimers.");
 		Pixmap retPixmap = new Pixmap(MINIMAP_WIDTH_PIXELS,MINIMAP_HEIGHT_PIXELS,Format.RGBA8888);
 		for (int count = 0; count < mobs.getRatCount(); count++) {
 			if (mobs.getRatByIndex(count) != null && mobs.getRatByIndex(count).active() == true)
@@ -141,6 +134,14 @@ public class MinimapRenderer implements Disposable {
 			{
 				retPixmap.setColor(Color.OLIVE);
 				retPixmap.drawPixel( (int)(mobs.getAimerByIndex(count).getBody().getPosition().x)+XOFFSET, MINIMAP_HEIGHT_PIXELS - (int)(mobs.getAimerByIndex(count).getBody().getPosition().y)+YOFFSET);
+			}
+		}
+		//draw sawrats on radar
+		for (int count = 0; count < mobs.getSawRatCount(); count++) {
+			if (mobs.getSawRatByIndex(count) != null && mobs.getSawRatByIndex(count).active() == true)
+			{
+				retPixmap.setColor(Color.BLUE);
+				retPixmap.drawPixel( (int)(mobs.getSawRatByIndex(count).getBody().getPosition().x)+XOFFSET, MINIMAP_HEIGHT_PIXELS - (int)(mobs.getSawRatByIndex(count).getBody().getPosition().y) + YOFFSET);
 			}
 		}
 		

--- a/core/src/thwack/view/MinimapRenderer.java
+++ b/core/src/thwack/view/MinimapRenderer.java
@@ -26,6 +26,9 @@ public class MinimapRenderer implements Disposable {
 	
 	float minimapAlpha = 0.5f;
 	Texture mapTerrainImage;
+	Pixmap terrainPixels;
+	Pixmap updatedRadar;
+	Texture radarImage;
 	
 	int MINIMAP_WIDTH_PIXELS = 64;
 	int MINIMAP_HEIGHT_PIXELS = 64;
@@ -49,14 +52,18 @@ public class MinimapRenderer implements Disposable {
 	
 		MobGroup mobs = thisDungeon.getCurrentStage().getMobs();
 		batch.draw(mapTerrainImage,-20f,70f);
-		Texture radarImage = new Texture(getUpdatedRadar(mobs), Format.RGBA8888, false);
+		if (updatedRadar != null) updatedRadar.dispose();
+		updatedRadar = getUpdatedRadar(mobs);
+		if (radarImage != null) radarImage.dispose();
+		radarImage = new Texture(updatedRadar, Format.RGBA8888, false);
 		batch.draw(radarImage,-20f,70f);
 		
 	}
 	
 	public void updateMapTerrain(TiledMap tiledMap) {
 		
-		Pixmap terrainPixels = new Pixmap(MINIMAP_WIDTH_PIXELS,MINIMAP_HEIGHT_PIXELS,Format.RGBA8888);
+		if (terrainPixels != null) terrainPixels.dispose();
+		terrainPixels = new Pixmap(MINIMAP_WIDTH_PIXELS,MINIMAP_HEIGHT_PIXELS,Format.RGBA8888);
 		
 		//Dark grey for floor, light grey for walls
 		Color floorColor = new Color(0.1f,0.1f,0.1f,minimapAlpha);
@@ -109,7 +116,9 @@ public class MinimapRenderer implements Disposable {
 			}
 		}
 		
+		if (mapTerrainImage != null) mapTerrainImage.dispose();
 		mapTerrainImage = new Texture(terrainPixels,Format.RGBA8888,false);
+		
 	}
 	
 	public Pixmap getUpdatedRadar(MobGroup mobs) {
@@ -121,6 +130,8 @@ public class MinimapRenderer implements Disposable {
 		//draw rats on radar
 		//Global.DebugOutLine("On minimap, ,drawing " + mobs.getRatCount() + " rats and " + mobs.getAimerCount() + "aimers.");
 		Pixmap retPixmap = new Pixmap(MINIMAP_WIDTH_PIXELS,MINIMAP_HEIGHT_PIXELS,Format.RGBA8888);
+		
+		
 		for (int count = 0; count < mobs.getRatCount(); count++) {
 			if (mobs.getRatByIndex(count) != null && mobs.getRatByIndex(count).active() == true)
 			{

--- a/core/src/thwack/view/RatRenderer.java
+++ b/core/src/thwack/view/RatRenderer.java
@@ -46,13 +46,9 @@ public class RatRenderer implements Disposable {
 		ratWalkAnim.put(Direction.RIGHT, new Animation(ratAnimSpeed, ratAtlas.findRegions("Run Right/Rat Run Side"), PlayMode.LOOP));
 		ratWalkAnim.put(Direction.UP, new Animation(ratAnimSpeed, ratAtlas.findRegions("Run Up/Rat Run Up"), PlayMode.LOOP));
 		ratBoredAnim1.put(Direction.DOWN, new Animation(ratAnimSpeed, ratAtlas.findRegions("Bored Down/Clean/Rat Clean Down"), PlayMode.LOOP));
-		System.out.println("Adding rat animation: " + ratAtlas.findRegions("Bored Down/Clean/Rat Clean Down"));
 		ratBoredAnim1.put(Direction.LEFT, new Animation(ratAnimSpeed, ratAtlas.findRegions("Bored Side/Clean/Rat Clean Side"), PlayMode.LOOP));
-		System.out.println("Adding rat animation: " + ratAtlas.findRegions("Bored Side/Clean/Rat Clean Side"));
 		ratBoredAnim1.put(Direction.RIGHT, new Animation(ratAnimSpeed, ratAtlas.findRegions("Bored Side/Clean/Rat Clean Side"), PlayMode.LOOP));
-		System.out.println("Adding rat animation: " + ratAtlas.findRegions("Bored Side/Clean/Rat Clean Side"));
 		ratBoredAnim1.put(Direction.UP, new Animation(ratAnimSpeed, ratAtlas.findRegions("Bored Up/Clean/Rat Clean Up"), PlayMode.LOOP));
-		System.out.println("Adding rat animation: " + ratAtlas.findRegions("Bored Up/Clean/Rat Clean Up"));
 
 		//i tweaked these to get the look times feeling right --radish
 		ratBoredAnim2.put(Direction.DOWN, new Animation(.75f, ratAtlas.findRegions("Bored Down/Look/Rat Look Down"), PlayMode.LOOP));

--- a/core/src/thwack/view/SawRatRenderer.java
+++ b/core/src/thwack/view/SawRatRenderer.java
@@ -4,7 +4,6 @@ import java.util.HashMap;
 import java.util.Map;
 
 import thwack.Constants;
-import thwack.model.entities.mobs.Rat;
 import thwack.model.entities.mobs.Mob.State;
 import thwack.model.entities.mobs.SawRat;
 import thwack.model.entity.Damageable.DamageState;
@@ -44,21 +43,13 @@ public class SawRatRenderer implements Disposable {
 		
 		float ratAnimSpeed = 0.075f;
 		ratWalkAnim.put(Direction.DOWN, new Animation(ratAnimSpeed, ratAtlas.findRegions("Run/Down/Saw Rat Down Run"), PlayMode.LOOP));
-		System.out.println("Adding sawrat animation: " + ratAtlas.findRegions("Run/Down/Saw Rat Down Run"));
 		ratWalkAnim.put(Direction.LEFT, new Animation(ratAnimSpeed, ratAtlas.findRegions("Run/Side/Saw Rat Side Run"), PlayMode.LOOP));
-		System.out.println("Adding sawrat animation: " + ratAtlas.findRegions("Run/Side/Saw Rat Side Run"));
 		ratWalkAnim.put(Direction.RIGHT, new Animation(ratAnimSpeed, ratAtlas.findRegions("Run/Side/Saw Rat Side Run"), PlayMode.LOOP));
-		System.out.println("Adding sawrat animation: " + ratAtlas.findRegions("Run/Side/Saw Rat Side Run"));
 		ratWalkAnim.put(Direction.UP, new Animation(ratAnimSpeed, ratAtlas.findRegions("Run/Up/Saw Rat Up Run"), PlayMode.LOOP));
-		System.out.println("Adding sawrat animation: " + ratAtlas.findRegions("Run/Up/Saw Rat Up Run"));
 		ratBoredAnim1.put(Direction.DOWN, new Animation(ratAnimSpeed, ratAtlas.findRegions("Idle/Down/Saw Rat Down Idle"), PlayMode.LOOP));
-		System.out.println("Adding sawrat animation: " + ratAtlas.findRegions("Idle/Down/Saw Rat Down Idle"));
 		ratBoredAnim1.put(Direction.LEFT, new Animation(ratAnimSpeed, ratAtlas.findRegions("Idle/Side/Saw Rat Side Idle"), PlayMode.LOOP));
-		System.out.println("Adding sawrat animation: " + ratAtlas.findRegions("Idle/Side/Saw Rat Side Idle"));
 		ratBoredAnim1.put(Direction.RIGHT, new Animation(ratAnimSpeed, ratAtlas.findRegions("Idle/Side/Saw Rat Side Idle"), PlayMode.LOOP));
-		System.out.println("Adding sawrat animation: " + ratAtlas.findRegions("Idle/Side/Saw Rat Side Idle"));
 		ratBoredAnim1.put(Direction.UP, new Animation(ratAnimSpeed, ratAtlas.findRegions("Idle/Up/Saw Rat Up Idle"), PlayMode.LOOP));
-		System.out.println("Adding sawrat animation: " + ratAtlas.findRegions("Idle/Up/Saw Rat Up Idle"));
 
 		//i tweaked these to get the look times feeling right --radish
 		ratBoredAnim2.put(Direction.DOWN, new Animation(.75f, ratAtlas.findRegions("Idle/Down/Saw Rat Down Idle"), PlayMode.LOOP));


### PR DESCRIPTION
If an enemy isn't hit for a few seconds, the lifebar fades away and is hidden
Fixed memory leak caused by failing to dispose textures and pixmaps in minimap and lifebar
